### PR TITLE
Add Netlify serverless proxy for OpenAI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ NOVA Inspector is a minimal web app that uses optical character recognition (OCR
 - Send the extracted text to an OpenAI model (default `gpt-4o-mini`) that returns the predicted NOVA category and a short explanation in Danish.
 
 ## Setup
-1. Edit `app.js` and replace `"[OPENAI API KEY]"` with your OpenAI API key.
-2. Open `index.html` in a browser or serve the folder with any static file server.
+1. Deploy the project to [Netlify](https://www.netlify.com/) or run `netlify dev` locally.
+2. Configure an environment variable `OPENAI_API_KEY` in Netlify containing your OpenAI API key.
+3. Open `index.html` in a browser or serve the folder with any static file server.
 
 ## Usage
 1. Click **Vælg foto af ingrediensliste** and choose an image file.
@@ -19,6 +20,6 @@ NOVA Inspector is a minimal web app that uses optical character recognition (OCR
 4. The predicted NOVA category and explanation appear below the button.
 
 ## Notes
-- The app runs entirely in the browser and stores no data on the server.
+- The OpenAI request is proxied through a Netlify serverless function; the API key is never exposed to the browser.
 - A network connection and valid OpenAI API key are required.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = "."
+  functions = "netlify/functions"

--- a/netlify/functions/classify.js
+++ b/netlify/functions/classify.js
@@ -1,0 +1,67 @@
+const OPENAI_URL = 'https://api.openai.com/v1/chat/completions';
+const OPENAI_MODEL = 'gpt-4o-mini';
+
+exports.handler = async function(event) {
+  try {
+    const { text } = JSON.parse(event.body || '{}');
+    if (!text) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Missing text' }) };
+    }
+
+    const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+    if (!OPENAI_API_KEY) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'API key not configured' }) };
+    }
+
+    const prompt = `
+Du er en NOVA-klassifikationsassistent.
+Returnér KUN et JSON-objekt:
+{"category":1|2|3|4,"description":"kort sætning på dansk hvorfor."}
+
+Ingrediensliste:
+${text}
+`.trim();
+
+    const body = {
+      model: OPENAI_MODEL,
+      messages: [
+        { role: 'system', content: 'Du klassificerer fødevarer i NOVA 1–4 og svarer kort på dansk.' },
+        { role: 'user', content: prompt }
+      ],
+      temperature: 0.1
+    };
+
+    const response = await fetch(OPENAI_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${OPENAI_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      const txt = await response.text().catch(() => '');
+      return { statusCode: response.status, body: JSON.stringify({ error: txt }) };
+    }
+
+    const json = await response.json();
+    const content = json?.choices?.[0]?.message?.content ?? '';
+    const match = content.match(/\{[\s\S]*\}/);
+    let result;
+    if (match) {
+      try {
+        result = JSON.parse(match[0]);
+      } catch {
+        result = { category: null, description: content.trim() };
+      }
+    } else {
+      result = { category: null, description: content.trim() || 'Kunne ikke udtrække resultat.' };
+    }
+
+    return { statusCode: 200, body: JSON.stringify(result) };
+  } catch (err) {
+    console.error(err);
+    return { statusCode: 500, body: JSON.stringify({ error: err.message || 'Server error' }) };
+  }
+};


### PR DESCRIPTION
## Summary
- Move OpenAI calls to a Netlify serverless function that reads the API key from `OPENAI_API_KEY`
- Update client app to call the Netlify function instead of embedding the key
- Add Netlify configuration and documentation for environment variable deployment

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check netlify/functions/classify.js`


------
https://chatgpt.com/codex/tasks/task_e_68986c2b4ca883298802693080b42c09