### PR TITLE
feat: add PWA support and emoji results

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ NOVA Inspector is a minimal web app that uses optical character recognition (OCR
 - Extract text using [Tesseract.js](https://tesseract.projectnaptha.com/) with Danish and English language support.
 - Send the extracted text to an OpenAI model (default `gpt-4o-mini`) that returns the predicted NOVA category and a short explanation in Danish.
 - Simple UI shows only the final NOVA category and explanation.
+- Installable as a Progressive Web App with offline caching and an emoji icon.
  
 ## Setup
 1. Deploy the project to [Netlify](https://www.netlify.com/) or run `netlify dev` locally.

--- a/app.js
+++ b/app.js
@@ -128,8 +128,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const text = (await runOCR(dataUrl)).trim();
 
       const nova = await classifyWithOpenAI(text);
+      const emojiMap = { 1: '🥕', 2: '🧂', 3: '🍞', 4: '🏭' };
       const cat = nova.category == null ? 'Ukendt' : `NOVA ${nova.category}`;
-      resultEl.textContent = `${cat} — ${nova.description || ''}`;
+      const emoji = emojiMap[nova.category] || '❓';
+      resultEl.textContent = `${emoji} ${cat} — ${nova.description || ''}`;
       setStatus('Færdig ✔');
     } catch (err) {
       console.error(err);

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>NOVA Inspector</title>
   <link rel="stylesheet" href="style.css" />
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20100%22%3E%3Ctext%20y%3D%22.9em%22%20font-size%3D%2290%22%3E%F0%9F%8D%8F%3C%2Ftext%3E%3C%2Fsvg%3E">
+  <meta name="theme-color" content="#ffcc00">
 </head>
 <body>
   <div class="container">
@@ -28,5 +31,12 @@
   <!-- Load Tesseract BEFORE app.js -->
   <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
   <script src="app.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js');
+      });
+    }
+  </script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "NOVA Inspector",
+  "short_name": "NOVA",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffcc00",
+  "icons": [
+    {
+      "src": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20100%22%3E%3Ctext%20y%3D%22.9em%22%20font-size%3D%2290%22%3E%F0%9F%8D%8F%3C%2Ftext%3E%3C%2Fsvg%3E",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,20 @@
+const CACHE_NAME = 'nova-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/app.js',
+  '/manifest.json',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add web app manifest, service worker, and emoji-based icon for PWA installability
- display NOVA category with an emoji for quick visual cues
- document PWA support in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68986e7320cc832991490479ab02304d